### PR TITLE
Improvement/rt/payment logos

### DIFF
--- a/inc/modules/payment-logos/class-payment-logos.php
+++ b/inc/modules/payment-logos/class-payment-logos.php
@@ -372,7 +372,7 @@ class Merchant_Payment_Logos extends Merchant_Add_Module {
 				<div class="merchant-payment-logos-images is-placeholder">
 					<?php foreach ( $logos as $logo_src ) : 
 						$logo_basename = basename( $logo_src );
-						$logo_alt      = ! empty( $placeholder_logos_alt[ $logo_basename ] ) ? $placeholder_logos_alt[ $logo_basename ] : '';
+						$logo_alt      = isset( $placeholder_logos_alt[ $logo_basename ] ) ? $placeholder_logos_alt[ $logo_basename ] : '';
 						?>
 						<img src="<?php echo esc_url( $logo_src ); ?>" alt="<?php echo esc_attr( $logo_alt ); ?>" />
 					<?php endforeach; ?>

--- a/inc/modules/payment-logos/class-payment-logos.php
+++ b/inc/modules/payment-logos/class-payment-logos.php
@@ -314,6 +314,19 @@ class Merchant_Payment_Logos extends Merchant_Add_Module {
 	}
 
 	/**
+	 * Get placeholder logos alternative descriptions.
+	 * 
+	 * @return array $logos_alt Array of logos alternative descriptions.
+	 */
+	public function get_placeholder_logos_alt_map() {
+		return array(
+			'visa.svg'   => __( 'Visa', 'merchant' ),
+			'master.svg' => __( 'Mastercard', 'merchant' ),
+			'pp.svg'     => __( 'PayPal', 'merchant' ),
+		);
+	}
+
+	/**
 	 * Render payment logos.
 	 * TODO: Render through template files.
 	 * 
@@ -331,7 +344,8 @@ class Merchant_Payment_Logos extends Merchant_Add_Module {
 		$settings       = $this->get_module_settings();
 		$is_placeholder = empty( $settings[ 'logos' ] ) ? true : false;
 
-		$logos  = $this->get_logos( $settings[ 'logos' ] );
+		$logos                 = $this->get_logos( $settings[ 'logos' ] );
+		$placeholder_logos_alt = $this->get_placeholder_logos_alt_map();
 
 		?>
 
@@ -347,25 +361,20 @@ class Merchant_Payment_Logos extends Merchant_Add_Module {
 
 				<div class="merchant-payment-logos-images">
 
-					<?php foreach ( $logos as $image_id ) : ?>
-
-						<?php $imagedata = wp_get_attachment_image_src( $image_id, 'full' ); ?>
-
-						<?php if ( ! empty( $imagedata ) && ! empty( $imagedata[0] ) ) : ?>
-
-							<?php printf( '<img src="%s" />', esc_url( $imagedata[0] ) ); ?>
-
-						<?php endif; ?>
-
-					<?php endforeach; ?>
+					<?php foreach ( $logos as $image_id ) {
+						echo wp_kses_post( wp_get_attachment_image( $image_id ) );
+					} ?>
 
 				</div>
 
 			<?php else : ?>
 
 				<div class="merchant-payment-logos-images is-placeholder">
-					<?php foreach ( $logos as $logo_src ) : ?>
-						<img src="<?php echo esc_url( $logo_src ); ?>" />
+					<?php foreach ( $logos as $logo_src ) : 
+						$logo_basename = basename( $logo_src );
+						$logo_alt      = ! empty( $placeholder_logos_alt[ $logo_basename ] ) ? $placeholder_logos_alt[ $logo_basename ] : '';
+						?>
+						<img src="<?php echo esc_url( $logo_src ); ?>" alt="<?php echo esc_attr( $logo_alt ); ?>" />
 					<?php endforeach; ?>
 				</div>
 

--- a/inc/modules/trust-badges/class-trust-badges.php
+++ b/inc/modules/trust-badges/class-trust-badges.php
@@ -354,7 +354,7 @@ class Merchant_Trust_Badges extends Merchant_Add_Module {
 						<div class="merchant-trust-badges-images is-placeholder">
 							<?php foreach ( $badges as $badge_src ) : 
 								$image_basename = basename( $badge_src );
-								$image_alt      = ! empty( $placeholder_badges_alt[ $image_basename ] ) ? $placeholder_badges_alt[ $image_basename ] : '';
+								$image_alt      = isset( $placeholder_badges_alt[ $image_basename ] ) ? $placeholder_badges_alt[ $image_basename ] : '';
 								?>
 								<img src="<?php echo esc_url( $badge_src ); ?>" alt="<?php echo esc_attr( $image_alt ); ?>" />
 							<?php endforeach; ?>

--- a/inc/modules/trust-badges/class-trust-badges.php
+++ b/inc/modules/trust-badges/class-trust-badges.php
@@ -299,6 +299,19 @@ class Merchant_Trust_Badges extends Merchant_Add_Module {
 	}
 
 	/**
+	 * Get placeholder badges alternative descriptions.
+	 * 
+	 * @return array $logos_alt Array of badges alternative descriptions.
+	 */
+	public function get_placeholder_badges_alt_map() {
+		return array(
+			'badge1.svg' => __( 'Original', 'merchant' ),
+			'badge2.svg' => __( '24/7 Support', 'merchant' ),
+			'badge3.svg' => __( 'Satisfaction', 'merchant' ),
+		);
+	}
+
+	/**
 	 * Render trust badges.
 	 * TODO: Render through template files.
 	 * 
@@ -313,9 +326,10 @@ class Merchant_Trust_Badges extends Merchant_Add_Module {
 			return;
 		}
 		
-		$settings       = $this->get_module_settings();
-		$is_placeholder = empty( $settings[ 'badges' ] ) ? true : false;
-		$badges         = $this->get_badges( $settings[ 'badges' ] );
+		$settings               = $this->get_module_settings();
+		$is_placeholder         = empty( $settings[ 'badges' ] ) ? true : false;
+		$badges                 = $this->get_badges( $settings[ 'badges' ] );
+		$placeholder_badges_alt = $this->get_placeholder_badges_alt_map();
 
 		?>
 
@@ -329,25 +343,20 @@ class Merchant_Trust_Badges extends Merchant_Add_Module {
 
 					<div class="merchant-trust-badges-images">
 
-						<?php foreach ( $badges as $image_id ) : ?>
-
-							<?php $imagedata = wp_get_attachment_image_src( $image_id, 'full' ); ?>
-
-							<?php if ( ! empty( $imagedata ) && ! empty( $imagedata[0] ) ) : ?>
-
-								<?php echo wp_kses_post( wp_get_attachment_image( $image_id ) ) ?>
-
-							<?php endif; ?>
-
-						<?php endforeach; ?>
+						<?php foreach ( $badges as $image_id ) {
+							echo wp_kses_post( wp_get_attachment_image( $image_id ) );
+						} ?>
 
 					</div>
 
 					<?php else : ?>
 
 						<div class="merchant-trust-badges-images is-placeholder">
-							<?php foreach ( $badges as $badge_src ) : ?>
-								<img src="<?php echo esc_url( $badge_src ); ?>" />
+							<?php foreach ( $badges as $badge_src ) : 
+								$image_basename = basename( $badge_src );
+								$image_alt      = ! empty( $placeholder_badges_alt[ $image_basename ] ) ? $placeholder_badges_alt[ $image_basename ] : '';
+								?>
+								<img src="<?php echo esc_url( $badge_src ); ?>" alt="<?php echo esc_attr( $image_alt ); ?>" />
 							<?php endforeach; ?>
 						</div>
 


### PR DESCRIPTION
This PR adds alt attributes to placeholder images from Payment Logos and Trust Badge modules. Also replaces the render from Payment Logo images from printf() to builntin WordPress wp_get_attachment_image() in favor of better compatibility with extra plugins and the WordPress itself.