### PR TITLE
Improvements in favor of better Botiga integration

### DIFF
--- a/assets/sass/admin/admin.scss
+++ b/assets/sass/admin/admin.scss
@@ -1537,7 +1537,7 @@ body.merchant-module-disabled {
 .merchant-module-page-setting-field-radio_alt,
 .merchant-module-page-setting-field-checkbox {
 
-  div {
+  div:not(.merchant-module-page-setting-field-desc) {
     display: flex;
     grid-gap: 30px;
   }

--- a/inc/classes/class-merchant-modules.php
+++ b/inc/classes/class-merchant-modules.php
@@ -40,7 +40,6 @@ if ( ! class_exists( 'Merchant_Modules' ) ) {
 		 * Constructor.
 		 */
 		public function __construct() {
-
 			add_action( 'wp_ajax_merchant_module_activate', array( $this, 'activate_module' ) );
 			add_action( 'wp_ajax_merchant_module_deactivate', array( $this, 'deactivate_module' ) );
 			add_action( 'wp_ajax_merchant_module_feedback', array( $this, 'feedback_module' ) );
@@ -65,6 +64,13 @@ if ( ! class_exists( 'Merchant_Modules' ) ) {
 				$modules[ $module ] = true;
 
 				update_option( self::$option, $modules );
+
+				/**
+				 * Hook 'merchant_admin_module_activated'
+				 * 
+				 * @since 1.9.3
+				 */
+				do_action( 'merchant_admin_module_activated', $module );
 
 				wp_send_json_success();
 
@@ -92,6 +98,13 @@ if ( ! class_exists( 'Merchant_Modules' ) ) {
 				$modules[ $module ] = false;
 
 				update_option( self::$option, $modules );
+
+				/**
+				 * Hook 'merchant_admin_module_deactivated'
+				 * 
+				 * @since 1.9.3
+				 */
+				do_action( 'merchant_admin_module_deactivated', $module );
 
 				wp_send_json_success();
 

--- a/inc/modules/class-add-module.php
+++ b/inc/modules/class-add-module.php
@@ -241,6 +241,6 @@ class Merchant_Add_Module {
 	 * @return bool
 	 */
 	public function is_shortcode_enabled() {
-		return Merchant_Admin_Options::get( $this->module_id, 'use_shortcode', false );
+		return apply_filters( "merchant_{$this->module_id}_is_shortcode_enabled", Merchant_Admin_Options::get( $this->module_id, 'use_shortcode', false ) );
 	}
 }

--- a/inc/modules/class-add-module.php
+++ b/inc/modules/class-add-module.php
@@ -241,6 +241,12 @@ class Merchant_Add_Module {
 	 * @return bool
 	 */
 	public function is_shortcode_enabled() {
+
+		/**
+		 * Hook 'merchant_{$this->module_id}_is_shortcode_enabled'
+		 * 
+		 * @since 1.9.3
+		 */
 		return apply_filters( "merchant_{$this->module_id}_is_shortcode_enabled", Merchant_Admin_Options::get( $this->module_id, 'use_shortcode', false ) );
 	}
 }

--- a/inc/modules/payment-logos/class-payment-logos.php
+++ b/inc/modules/payment-logos/class-payment-logos.php
@@ -196,7 +196,7 @@ class Merchant_Payment_Logos extends Merchant_Add_Module {
 		 *
 		 * @since 1.8
 		 */
-		return apply_filters( 'merchant_module_shortcode_content_html', $shortcode_content, $this->module->module_id, get_the_ID() );
+		return apply_filters( 'merchant_module_shortcode_content_html', $shortcode_content, $this->module_id, get_the_ID() );
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces:
- Filter `merchant_{$this->module_id}_is_shortcode_enabled` to the value from `is_shortcode_enabled` method.
- Actions `merchant_admin_module_activated` and `merchant_admin_module_deactivated` to modules activation/deactivation ajax callbacks. 
- New argument `$module_id` to Merchant_Admin_Options methods used to render admin settings fields. 