### PR TITLE
Improved Stickty Add to Cart Flatsome theme compatibility

### DIFF
--- a/assets/sass/compatibility/flatsome/style.scss
+++ b/assets/sass/compatibility/flatsome/style.scss
@@ -1,0 +1,34 @@
+.merchant-theme-flatsome {
+
+	/* Sticky Add To Cart */
+	.merchant-sticky-add-to-cart-wrapper {
+		.merchant-sticky-add-to-cart-wrapper-content {
+			.merchant-sticky-add-to-cart-item.product-addtocart {
+				form.cart {
+					margin-bottom: 0;
+
+					.ux-quantity__button.ux-quantity__button--minus,
+					.ux-quantity__button.ux-quantity__button--plus {
+						margin: 0;
+					}
+
+					.input-text.qty {
+						height: auto;
+					}
+					
+					.single_add_to_cart_button {
+						margin-bottom: 0;
+					}
+					
+				}
+			}
+		}
+	}
+
+	.merchant-sticky-add-to-cart-wrapper-content-mobile {
+		.button.merchant-mobile-sticky-addtocart-button {
+			margin-bottom: 0;
+		}
+	}
+		
+}

--- a/inc/class-merchant-loader.php
+++ b/inc/class-merchant-loader.php
@@ -113,6 +113,7 @@ if ( ! class_exists( 'Merchant_Loader' ) ) {
 			require_once MERCHANT_DIR . 'inc/compatibility/class-merchant-oceanwp-theme.php';
 			require_once MERCHANT_DIR . 'inc/compatibility/class-merchant-twenty-twenty-four-theme.php';
 			require_once MERCHANT_DIR . 'inc/compatibility/class-merchant-blocksy-theme.php';
+			require_once MERCHANT_DIR . 'inc/compatibility/class-merchant-flatsome-theme.php';
 
 			/**
 			 * Hook 'merchant_admin_after_include_modules_classes'.

--- a/inc/compatibility/class-merchant-flatsome-theme.php
+++ b/inc/compatibility/class-merchant-flatsome-theme.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Flatsome theme compatibility layer
+ */
+if ( ! class_exists( 'Merchant_Flatsome_Theme' ) ) {
+	class Merchant_Flatsome_Theme {
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			add_action( 'wp_enqueue_scripts', array( $this, 'styles' ) );
+		}
+
+		/**
+		 * Load compatibility styles if the Flatsome theme is installed and active.
+		 *
+		 * @return void
+		 */
+		public function styles() {
+			if ( ! merchant_is_flatsome_active() ) {
+				return;
+			}
+
+			wp_enqueue_style(
+				'merchant-flatsome-compatibility',
+				MERCHANT_URI . 'assets/css/compatibility/flatsome/style.min.css',
+				array(),
+				MERCHANT_VERSION
+			);
+		}
+	}
+
+	/**
+	 * The class object can be accessed with "global $flatsome_compatibility", to allow removing actions.
+	 * Improving Third-party integrations.
+	 */
+	$merchant_flatsome_compatibility = new Merchant_Flatsome_Theme();
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -127,6 +127,17 @@ if ( ! function_exists( 'merchant_is_blocksy_active' ) ) {
 }
 
 /**
+ * Check if Flatsome theme is installed and active.
+ *
+ * @return bool
+ */
+if ( ! function_exists( 'merchant_is_flatsome_active' ) ) {
+    function merchant_is_flatsome_active() {
+        return class_exists( 'Flatsome' );
+    }
+}
+
+/**
  * Check if any shortcode starts with merchant.
  * If the shortcode is not registered, register it with return null to guarantee it exists.
  */

--- a/wpgulp.config.js
+++ b/wpgulp.config.js
@@ -570,6 +570,12 @@ const styles = [
 		src: './assets/sass/compatibility/twenty-twenty-four/style.scss',
 		destination: './assets/css/compatibility/twenty-twenty-four',
 	},
+
+	{
+		name: 'flatsomeCompatibility',
+		src: './assets/sass/compatibility/flatsome/style.scss',
+		destination: './assets/css/compatibility/flatsome',
+	},
 ];
 
 // Scripts to process.
@@ -838,15 +844,15 @@ const scripts = [
 ];
 
 // Watch options.
-const watchStyles  = './assets/sass/**/*.scss';
+const watchStyles = './assets/sass/**/*.scss';
 const watchScripts = './assets/js/src/**/*.js';
-const watchPhp     = './**/*.php';
+const watchPhp = './**/*.php';
 
 // Zip options.
-const zipName        = 'merchant.zip';
+const zipName = 'merchant.zip';
 const zipDestination = './../';
 const zipIncludeGlob = ['../@(Merchant|merchant)/**/*'];
-const zipIgnoreGlob  = [
+const zipIgnoreGlob = [
 	'!../@(Merchant|merchant)/**/*{node_modules,node_modules/**/*}',
 	'!../@(Merchant|merchant)/**/*.code-workspace',
 	'!../@(Merchant|merchant)/**/*.git',
@@ -881,16 +887,16 @@ const zipIgnoreGlob  = [
 ];
 
 // Translation options.
-const textDomain             = 'merchant';
-const translationFile        = 'merchant.pot';
+const textDomain = 'merchant';
+const translationFile = 'merchant.pot';
 const translationDestination = './languages';
 
 // Others.
-const packageName    = 'merchant';
-const bugReport      = 'https://athemes.com/contact/';
+const packageName = 'merchant';
+const bugReport = 'https://athemes.com/contact/';
 const lastTranslator = 'aThemes <team@athemes.com>';
-const team           = 'aThemes <team@athemes.com>';
-const BROWSERS_LIST  = ['last 2 version', '> 1%'];
+const team = 'aThemes <team@athemes.com>';
+const BROWSERS_LIST = ['last 2 version', '> 1%'];
 
 // Export.
 module.exports = {


### PR DESCRIPTION
Task: [Sticky Add to Cart Feature Compatibility with Flatsome Theme](https://github.com/orgs/athemes/projects/7/views/8?pane=issue&itemId=54581616)

Changelog:

- Added: Flatsome Theme Compatibility structural files for all modules.
- Fixed: Sticky Add to Cart module Input quantity field size and position.
- Fixed: Sticky Add to Cart module Add to cart button position.

Before Compatibility:

![Before Compatibility](https://img001.prntscr.com/file/img001/RvPoabKhQuWHdUTH9PrJrQ.png)

After Compatibility:
![After Compatibility](https://img001.prntscr.com/file/img001/GK5o6m2qSOqYXLrT5L73jw.png)
