### PR TITLE
Re-order module options and update admin help section hook

### DIFF
--- a/inc/modules/pre-orders/admin/options.php
+++ b/inc/modules/pre-orders/admin/options.php
@@ -10,79 +10,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
+/**
+ * Hook functionality before including modules options.
+ *
+ * @since 1.9.8
+ */
+do_action( 'merchant_admin_before_include_modules_options', Merchant_Pre_Orders::MODULE_ID );
+
 Merchant_Admin_Options::create(
 	array(
 		'title'  => esc_html__( 'Pre-order Rule', 'merchant' ),
 		'module' => Merchant_Pre_Orders::MODULE_ID,
 		'fields' => array(
-			array(
-				'id'      => 'modes',
-				'type'    => 'select',
-				'title'   => esc_html__( 'Pre-order Modes', 'merchant' ),
-				'options' => array(
-					'only_pre_orders'                => esc_html__( 'Allow only pre-orders', 'merchant' ),
-					'unified_order'                  => esc_html__( 'Treat the whole order as pre-order', 'merchant' ),
-					'separate_order_for_pre_orders'  => esc_html__( 'Generate separate orders for each pre-order product', 'merchant' ),
-					'group_pre_order_into_one_order' => esc_html__( 'Generate two separate orders, one for pre-orders and one for in-stock products', 'merchant' ),
-				),
-				'default' => 'unified_order',
-			),
-			array(
-				'id'          => 'helping_instructions_only_pre_orders',
-				'type'        => 'info_block',
-				'description' => esc_html__( 'Use this mode if you want to only allow your customers to either choose pre-order products or available ones.', 'merchant' ),
-				'conditions'  => array(
-					'terms' => array(
-						array(
-							'field'    => 'modes', // field ID
-							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
-							'value'    => 'only_pre_orders', // can be a single value or an array of string/number/int
-						),
-					),
-				),
-			),
-			array(
-				'id'          => 'helping_instructions_unified_order',
-				'type'        => 'info_block',
-				'description' => esc_html__( 'Use this mode if you want to treat the whole order as a pre-order if at least one product is a pre-order.', 'merchant' ),
-				'conditions'  => array(
-					'terms' => array(
-						array(
-							'field'    => 'modes', // field ID
-							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
-							'value'    => 'unified_order', // can be a single value or an array of string/number/int
-						),
-					),
-				),
-			),
-			array(
-				'id'          => 'helping_instructions_separate_order_for_pre_orders',
-				'type'        => 'info_block',
-				'description' => esc_html__( 'Use this mode if you want to generate separate orders for each pre-order product.', 'merchant' ),
-				'conditions'  => array(
-					'terms' => array(
-						array(
-							'field'    => 'modes', // field ID
-							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
-							'value'    => 'separate_order_for_pre_orders', // can be a single value or an array of string/number/int
-						),
-					),
-				),
-			),
-			array(
-				'id'          => 'helping_instructions_group_pre_order_into_one_order',
-				'type'        => 'info_block',
-				'description' => esc_html__( 'Use this mode if you want to generate two separate orders, one for pre-orders and one for in-stock products.', 'merchant' ),
-				'conditions'  => array(
-					'terms' => array(
-						array(
-							'field'    => 'modes', // field ID
-							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
-							'value'    => 'group_pre_order_into_one_order', // can be a single value or an array of string/number/int
-						),
-					),
-				),
-			),
 			array(
 				'id'           => 'rules',
 				'type'         => 'flexible_content',
@@ -315,6 +254,74 @@ Merchant_Admin_Options::create(
 				'default'      => array(
 					array(
 						'layout' => 'rule-details',
+					),
+				),
+			),
+			array(
+				'id'      => 'modes',
+				'type'    => 'select',
+				'title'   => esc_html__( 'Pre-order Modes', 'merchant' ),
+				'options' => array(
+					'only_pre_orders'                => esc_html__( 'Allow only pre-orders', 'merchant' ),
+					'unified_order'                  => esc_html__( 'Treat the whole order as pre-order', 'merchant' ),
+					'separate_order_for_pre_orders'  => esc_html__( 'Generate separate orders for each pre-order product', 'merchant' ),
+					'group_pre_order_into_one_order' => esc_html__( 'Generate two separate orders, one for pre-orders and one for in-stock products', 'merchant' ),
+				),
+				'default' => 'unified_order',
+			),
+			array(
+				'id'          => 'helping_instructions_only_pre_orders',
+				'type'        => 'info_block',
+				'description' => esc_html__( 'Use this mode if you want to only allow your customers to either choose pre-order products or available ones.', 'merchant' ),
+				'conditions'  => array(
+					'terms' => array(
+						array(
+							'field'    => 'modes', // field ID
+							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
+							'value'    => 'only_pre_orders', // can be a single value or an array of string/number/int
+						),
+					),
+				),
+			),
+			array(
+				'id'          => 'helping_instructions_unified_order',
+				'type'        => 'info_block',
+				'description' => esc_html__( 'Use this mode if you want to treat the whole order as a pre-order if at least one product is a pre-order.', 'merchant' ),
+				'conditions'  => array(
+					'terms' => array(
+						array(
+							'field'    => 'modes', // field ID
+							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
+							'value'    => 'unified_order', // can be a single value or an array of string/number/int
+						),
+					),
+				),
+			),
+			array(
+				'id'          => 'helping_instructions_separate_order_for_pre_orders',
+				'type'        => 'info_block',
+				'description' => esc_html__( 'Use this mode if you want to generate separate orders for each pre-order product.', 'merchant' ),
+				'conditions'  => array(
+					'terms' => array(
+						array(
+							'field'    => 'modes', // field ID
+							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
+							'value'    => 'separate_order_for_pre_orders', // can be a single value or an array of string/number/int
+						),
+					),
+				),
+			),
+			array(
+				'id'          => 'helping_instructions_group_pre_order_into_one_order',
+				'type'        => 'info_block',
+				'description' => esc_html__( 'Use this mode if you want to generate two separate orders, one for pre-orders and one for in-stock products.', 'merchant' ),
+				'conditions'  => array(
+					'terms' => array(
+						array(
+							'field'    => 'modes', // field ID
+							'operator' => '===', // Available operators: ===, !==, >, <, >=, <=, in, !in, contains, !contains
+							'value'    => 'group_pre_order_into_one_order', // can be a single value or an array of string/number/int
+						),
 					),
 				),
 			),

--- a/inc/modules/pre-orders/class-pre-orders.php
+++ b/inc/modules/pre-orders/class-pre-orders.php
@@ -81,9 +81,6 @@ class Merchant_Pre_Orders extends Merchant_Add_Module {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_css' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_js' ) );
 
-			// Render module essencial instructions before the module page body content.
-			add_action( 'merchant_admin_after_module_page_page_header', array( $this, 'admin_module_essencial_instructions' ) );
-
 			// Admin preview box.
 			add_filter( 'merchant_module_preview', array( $this, 'render_admin_preview' ), 10, 2 );
 
@@ -91,6 +88,8 @@ class Merchant_Pre_Orders extends Merchant_Add_Module {
 			// The custom CSS should be added here as well due to ensure preview box works properly.
 			add_filter( 'merchant_custom_css', array( $this, 'admin_custom_css' ) );
 		}
+
+		add_action( 'merchant_admin_before_include_modules_options', array( $this, 'help_banner' ) );
 
 		if ( Merchant_Modules::is_module_active( self::MODULE_ID ) && is_admin() ) {
 			// Init translations.
@@ -232,7 +231,7 @@ class Merchant_Pre_Orders extends Merchant_Add_Module {
 	 * @return array $setting The merchant global object setting parameter.
 	 */
 	public function localize_script( $setting ) {
-		$module_settings = $this->get_module_settings();
+		//$module_settings = $this->get_module_settings();
 
 		$setting['pre_orders'] = true;
 		$rule                  = $this->current_rule();
@@ -243,36 +242,6 @@ class Merchant_Pre_Orders extends Merchant_Add_Module {
 		}
 
 		return $setting;
-	}
-
-	/**
-	 * Render module essencial instructions.
-	 *
-	 * @return void
-	 */
-	public function admin_module_essencial_instructions() { ?>
-        <div class="merchant-module-page-settings">
-            <div class="merchant-module-page-setting-box merchant-module-page-setting-box-style-2">
-                <div class="merchant-module-page-setting-title"><?php
-					echo esc_html__( 'Tag Pre-Orders', 'merchant' ); ?></div>
-                <div class="merchant-module-page-setting-fields">
-                    <div class="merchant-module-page-setting-field merchant-module-page-setting-field-content">
-                        <div class="merchant-module-page-setting-field-inner">
-                            <div class="merchant-tag-pre-orders">
-                                <i class="dashicons dashicons-info"></i>
-                                <p><?php
-									echo esc_html__( 'Pre-orders captured by Merchant are tagged with "MerchantPreOrder" and can be found in your WooCommerce Order Section.',
-										'merchant' ); ?><?php
-									printf( '<a href="%s" target="_blank">%s</a>', esc_url( admin_url( 'edit.php?post_type=shop_order' ) ),
-										esc_html__( 'View Pre-Orders', 'merchant' ) ); ?></p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-		<?php
 	}
 
 	/**
@@ -432,6 +401,39 @@ class Merchant_Pre_Orders extends Merchant_Add_Module {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Help banner.
+	 *
+	 * @return void
+	 */
+	public function help_banner( $module_id ) {
+		if ( $module_id === 'pre-orders' ) {
+			?>
+            <div class="merchant-module-page-setting-fields">
+                <div class="merchant-module-page-setting-field merchant-module-page-setting-field-content">
+                    <div class="merchant-module-page-setting-field-inner">
+                        <div class="merchant-tag-pre-orders">
+                            <i class="dashicons dashicons-info"></i>
+                            <p>
+								<?php
+								echo esc_html__(
+									'Pre-orders captured by Merchant are tagged with "MerchantPreOrder" and can be found in your WooCommerce Order Section.',
+									'merchant'
+								);
+								printf(
+									'<a href="%1s" target="_blank">%2s</a>',
+									esc_url( admin_url( 'edit.php?post_type=shop_order' ) ),
+									esc_html__( 'View Pre-Orders', 'merchant' )
+								);
+								?></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+			<?php
+		}
 	}
 }
 

--- a/inc/modules/product-bundles/class-product-bundles.php
+++ b/inc/modules/product-bundles/class-product-bundles.php
@@ -73,30 +73,32 @@ class Merchant_Product_Bundles extends Merchant_Add_Module {
      *
      * @return void
      */
-	public function help_banner() {
-		?>
-        <div class="merchant-module-page-setting-fields">
-            <div class="merchant-module-page-setting-field merchant-module-page-setting-field-content">
-                <div class="merchant-module-page-setting-field-inner">
-                    <div class="merchant-tag-pre-orders">
-                        <i class="dashicons dashicons-info"></i>
-                        <p>
-						<?php
-						echo esc_html__(
-							'To create a new product bundle (simple or variable), go to Products > Add New menu in the left sidebar of your WordPress admin area.',
-							'merchant'
-						);
-						printf(
-							'<a href="%1s" target="_blank">%2s</a>',
-							esc_url( admin_url( 'post-new.php?post_type=product' ) ),
-							esc_html__( 'Add New Bundle', 'merchant' )
-						);
-						?></p>
+	public function help_banner( $module_id ) {
+		if ( $module_id === 'product-bundles' ) {
+			?>
+            <div class="merchant-module-page-setting-fields">
+                <div class="merchant-module-page-setting-field merchant-module-page-setting-field-content">
+                    <div class="merchant-module-page-setting-field-inner">
+                        <div class="merchant-tag-pre-orders">
+                            <i class="dashicons dashicons-info"></i>
+                            <p>
+								<?php
+								echo esc_html__(
+									'To create a new product bundle (simple or variable), go to Products > Add New menu in the left sidebar of your WordPress admin area.',
+									'merchant'
+								);
+								printf(
+									'<a href="%1s" target="_blank">%2s</a>',
+									esc_url( admin_url( 'post-new.php?post_type=product' ) ),
+									esc_html__( 'Add New Bundle', 'merchant' )
+								);
+								?></p>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-		<?php
+			<?php
+		}
 	}
 
 	/**


### PR DESCRIPTION
- Reorder pre-orders module options to make the modes below the pre order rules.
- Add help instructions above the module options