### PR TITLE
Fix missing Woo label

### DIFF
--- a/inc/modules/buy-now/class-buy-now.php
+++ b/inc/modules/buy-now/class-buy-now.php
@@ -33,13 +33,17 @@ class Merchant_Buy_Now extends Merchant_Add_Module {
 	 *
 	 */
 	public function __construct() {
+
+		// Module id.
+		$this->module_id = self::MODULE_ID;
+
+		// WooCommerce only.
+		$this->wc_only = true;
+
 		parent::__construct();
 
 		// Module section.
 		$this->module_section = 'reduce-abandonment';
-
-		// Module id.
-		$this->module_id = self::MODULE_ID;
 
 		// Module default settings.
 		$this->module_default_settings = array(


### PR DESCRIPTION
Ref: [Buy Now module is missing the Woo label](https://www.notion.so/athemes/Buy-Now-module-is-missing-the-Woo-label-1230e5658d7f4002baa41df0e4a97d59)