### PR TITLE
Add new logic to save text input fields in the admin options framework

### DIFF
--- a/admin/classes/class-merchant-admin-options.php
+++ b/admin/classes/class-merchant-admin-options.php
@@ -599,6 +599,8 @@ if ( ! class_exists( 'Merchant_Admin_Options' ) ) {
 				if ( ! $value && ( 0 !== $value && '0' !== $value ) ) {
 					if ( $type === 'checkbox_multiple' ) {
 						$value = is_array( $value ) ? $value : (array) $default;
+					} elseif ( $type === 'text' && ! empty( $module_id ) ) {
+						$value = Merchant_Option::get( $module_id, $id );
 					} else {
 						$value = $default;
 					}


### PR DESCRIPTION
The new behavior is:
- If there's no entry from the field in the database, display the default value.
- If there's a entry in the database (even empty values), display the entry value. 