### PR TITLE
Fix modules doesn't being added to the main merchant modules class

### DIFF
--- a/inc/analytics/class-merchant-analytics-data-reports.php
+++ b/inc/analytics/class-merchant-analytics-data-reports.php
@@ -527,7 +527,7 @@ class Merchant_Analytics_Data_Reports {
 		foreach ( $all_modules as $module_id => $module ) {
 			if ( Merchant_Modules::is_module_active( $module_id ) ) {
 				$module_object = Merchant_Modules::get_module( $module_id );
-				if ( $module_object->has_analytics() ) {
+				if ( $module_object && $module_object->has_analytics() ) {
 					$modules[ $module_id ] = array(
 						'module_object' => $module_object,
 						'metrics'       => $module_object->analytics_metrics(),

--- a/inc/modules/agree-to-terms-checkbox/class-agree-to-terms-checkbox.php
+++ b/inc/modules/agree-to-terms-checkbox/class-agree-to-terms-checkbox.php
@@ -272,5 +272,5 @@ class Merchant_Agree_To_Terms_Checkbox extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function () {
-	new Merchant_Agree_To_Terms_Checkbox();
+	Merchant_Modules::create_module( new Merchant_Agree_To_Terms_Checkbox() );
 } );

--- a/inc/modules/animated-add-to-cart/class-animated-add-to-cart.php
+++ b/inc/modules/animated-add-to-cart/class-animated-add-to-cart.php
@@ -321,5 +321,5 @@ class Merchant_Animated_Add_To_Cart extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Animated_Add_To_Cart();
+	Merchant_Modules::create_module( new Merchant_Animated_Add_To_Cart() );
 } );

--- a/inc/modules/auto-external-links/class-auto-external-links.php
+++ b/inc/modules/auto-external-links/class-auto-external-links.php
@@ -147,5 +147,5 @@ class Merchant_Auto_External_Links extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Auto_External_Links();
+    Merchant_Modules::create_module( new Merchant_Auto_External_Links() );
 } );

--- a/inc/modules/buy-now/class-buy-now.php
+++ b/inc/modules/buy-now/class-buy-now.php
@@ -469,5 +469,5 @@ class Merchant_Buy_Now extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Buy_Now();
+	Merchant_Modules::create_module( new Merchant_Buy_Now() );
 } );

--- a/inc/modules/cart-count-favicon/class-cart-count-favicon.php
+++ b/inc/modules/cart-count-favicon/class-cart-count-favicon.php
@@ -257,5 +257,5 @@ class Merchant_Cart_Count_Favicon extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Cart_Count_Favicon();
+	Merchant_Modules::create_module( new Merchant_Cart_Count_Favicon() );
 } );

--- a/inc/modules/cookie-banner/class-cookie-banner.php
+++ b/inc/modules/cookie-banner/class-cookie-banner.php
@@ -274,5 +274,5 @@ class Merchant_Cookie_Banner extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Cookie_Banner();
+	Merchant_Modules::create_module( new Merchant_Cookie_Banner() );
 } );

--- a/inc/modules/inactive-tab-message/class-inactive-tab-message.php
+++ b/inc/modules/inactive-tab-message/class-inactive-tab-message.php
@@ -229,5 +229,5 @@ class Merchant_Inactive_Tab_Message extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Inactive_Tab_Message();
+	Merchant_Modules::create_module( new Merchant_Inactive_Tab_Message() );
 } );

--- a/inc/modules/payment-logos/class-payment-logos.php
+++ b/inc/modules/payment-logos/class-payment-logos.php
@@ -523,5 +523,5 @@ class Merchant_Payment_Logos extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Payment_Logos();
+	Merchant_Modules::create_module( new Merchant_Payment_Logos() );
 } );

--- a/inc/modules/pre-orders/class-pre-orders.php
+++ b/inc/modules/pre-orders/class-pre-orders.php
@@ -488,5 +488,5 @@ require MERCHANT_DIR . 'inc/modules/pre-orders/class-pre-orders-main-functionali
 
 // Initialize the module.
 add_action( 'init', function () {
-	new Merchant_Pre_Orders( new Merchant_Pre_Orders_Main_Functionality() );
+	Merchant_Modules::create_module( new Merchant_Pre_Orders( new Merchant_Pre_Orders_Main_Functionality() ) );
 } );

--- a/inc/modules/product-labels/class-product-labels.php
+++ b/inc/modules/product-labels/class-product-labels.php
@@ -1178,5 +1178,5 @@ class Merchant_Product_Labels extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function () {
-	new Merchant_Product_Labels();
+	Merchant_Modules::create_module( new Merchant_Product_Labels() );
 } );

--- a/inc/modules/quick-view/class-quick-view.php
+++ b/inc/modules/quick-view/class-quick-view.php
@@ -929,5 +929,5 @@ class Merchant_Quick_View extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	Merchant_Quick_View::get_instance();
+	Merchant_Modules::create_module( Merchant_Quick_View::get_instance() );
 } );

--- a/inc/modules/real-time-search/class-real-time-search.php
+++ b/inc/modules/real-time-search/class-real-time-search.php
@@ -521,5 +521,5 @@ class Merchant_Real_Time_Search extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Real_Time_Search();
+	Merchant_Modules::create_module( new Merchant_Real_Time_Search() );
 } );

--- a/inc/modules/scroll-to-top-button/class-scroll-to-top-button.php
+++ b/inc/modules/scroll-to-top-button/class-scroll-to-top-button.php
@@ -283,5 +283,5 @@ class Merchant_Scroll_To_Top_Button extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Scroll_To_Top_Button();
+	Merchant_Modules::create_module( new Merchant_Scroll_To_Top_Button() );
 } );

--- a/inc/modules/trust-badges/class-trust-badges.php
+++ b/inc/modules/trust-badges/class-trust-badges.php
@@ -423,5 +423,5 @@ class Merchant_Trust_Badges extends Merchant_Add_Module {
 
 // Initialize the module.
 add_action( 'init', function() {
-	new Merchant_Trust_Badges();
+	Merchant_Modules::create_module( new Merchant_Trust_Badges() );
 } );


### PR DESCRIPTION
Fix modules that doesn't being added to `Merchant_Modules` class when initialization
Converting it to `Merchant_Modules::create_module( new Module_Class() );`